### PR TITLE
Review fhu 12/6

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -53,7 +53,7 @@ func (dst *Bitmap) And(b Bitmap) {
 		simd.And(a, b)
 	} else {
 		a := *dst
-		for i := 0; i < len(a); i++ {
+		for i := 0; i < len(b); i++ {
 			a[i] = a[i] & b[i]
 		}
 	}
@@ -69,7 +69,7 @@ func (dst *Bitmap) AndNot(b Bitmap) {
 	if simd.Supported {
 		simd.AndNot(a, b)
 	} else {
-		for i := 0; i < len(a); i++ {
+		for i := 0; i < len(b); i++ {
 			a[i] = a[i] &^ b[i]
 		}
 	}
@@ -85,7 +85,7 @@ func (dst *Bitmap) Or(b Bitmap) {
 	if simd.Supported {
 		simd.Or(a, b)
 	} else {
-		for i := 0; i < len(a); i++ {
+		for i := 0; i < len(b); i++ {
 			a[i] = a[i] | b[i]
 		}
 	}
@@ -101,7 +101,7 @@ func (dst *Bitmap) Xor(b Bitmap) {
 	if simd.Supported {
 		simd.Xor(a, b)
 	} else {
-		for i := 0; i < len(a); i++ {
+		for i := 0; i < len(b); i++ {
 			a[i] = a[i] ^ b[i]
 		}
 	}
@@ -146,11 +146,24 @@ func (dst Bitmap) FirstZero() (uint32, bool) {
 	return 0, false
 }
 
-// grow gros whe size of the bitmap until we reach the desired block offset
+// grow grows the size of the bitmap until we reach the desired block offset
 func (dst *Bitmap) grow(blkAt int) {
-	for i := len(*dst); i <= blkAt; i++ {
-		*dst = append(*dst, 0)
+	// Note that a bitmap is automatically initialized with zeros.
+
+	// If blkAt is no greater that the current length, do nothing.
+	if len(*dst) > blkAt {
+		return
 	}
+
+	// If blkAt is no greater than the current capacity, resize the slice without copying.
+	if cap(*dst) > blkAt {
+		*dst = (*dst)[:blkAt+1]
+		return
+	}
+
+	old := *dst
+	*dst = make(Bitmap, blkAt+1)
+	copy(*dst, old)
 }
 
 // balance grows the destination bitmap to match the size of the source bitmap.

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -285,3 +285,26 @@ func TestFirstZero(t *testing.T) {
 		assert.Equal(t, 0, int(v))
 	}
 }
+
+func TestGrow(t *testing.T) {
+	bitmap := make(Bitmap, 1, 5)
+	bitmap[0] = 42
+
+	assert.Equal(t, 1, len(bitmap))
+	assert.Equal(t, 5, cap(bitmap))
+	assert.Equal(t, Bitmap{42}, bitmap)
+
+	bitmap.grow(0)
+	assert.Equal(t, 1, len(bitmap))
+	assert.Equal(t, 5, cap(bitmap))
+	assert.Equal(t, Bitmap{42}, bitmap)
+
+	bitmap.grow(4)
+	assert.Equal(t, 5, len(bitmap))
+	assert.Equal(t, 5, cap(bitmap))
+	assert.Equal(t, Bitmap{42, 0, 0, 0, 0}, bitmap)
+
+	bitmap.grow(5)
+	assert.Equal(t, 6, len(bitmap))
+	assert.Equal(t, Bitmap{42, 0, 0, 0, 0, 0}, bitmap)
+}


### PR DESCRIPTION
- Fix logical operations on bitmap: loop on len(b) instead of len(a). 
- Rewrite the grow function to avoid potentially duplicating the Bitmap
several times if capacity is exceeded more than once in the loop of the
original algorithm.
- Tests for the grow function.
- Fix typo.