### PR TITLE
Fix bitmap shrinking

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -117,6 +117,21 @@ func (dst *Bitmap) Grow(desiredBit uint32) {
 	dst.grow(int(desiredBit >> 6))
 }
 
+// balance grows the destination bitmap to match the size of the source bitmap.
+func (dst *Bitmap) balance(src Bitmap) {
+	if len(*dst) == len(src) {
+		return
+	}
+
+	// Grow if necessary
+	if len(*dst) < len(src) {
+		dst.grow(len(src) - 1)
+		return
+	}
+
+	dst.shrink(len(src))
+}
+
 // grow grows the size of the bitmap until we reach the desired block offset
 func (dst *Bitmap) grow(blkAt int) {
 	// Note that a bitmap is automatically initialized with zeros.
@@ -137,13 +152,15 @@ func (dst *Bitmap) grow(blkAt int) {
 	copy(*dst, old)
 }
 
-// balance grows the destination bitmap to match the size of the source bitmap.
-func (dst *Bitmap) balance(src Bitmap) {
-	if len(*dst) < len(src) {
-		dst.grow(len(src) - 1)
-	} else {
-		*dst = (*dst)[:len(src)]
+// shrink shrinks the size of the bitmap and resets to zero
+func (dst *Bitmap) shrink(length int) {
+	until := len(*dst)
+	for i := length; i < until; i++ {
+		(*dst)[i] = 0
 	}
+
+	// Trim without reallocating
+	*dst = (*dst)[:length]
 }
 
 // capacityFor computes the next power of 2 for a given index

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -386,3 +386,23 @@ func TestAnd_DifferentBitmapSizes(t *testing.T) {
 	assert.Equal(t, 50, a.Count())
 	assert.Equal(t, 50, d.Count())
 }
+
+func TestAnd_ConsecutiveAnd_DifferentBitmapSizes(t *testing.T) {
+	var a, b, c Bitmap
+	for i := uint32(0); i < 200; i += 2 {
+		a.Set(i)
+		c.Set(i)
+	}
+
+	for i := uint32(0); i < 100; i += 2 {
+		b.Set(i)
+	}
+
+	a.And(b)
+	a.And(c)
+
+	for i := uint32(0); i < 200; i++ {
+		assert.Equal(t, a.Contains(i), b.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	assert.Equal(t, 50, a.Count())
+}


### PR DESCRIPTION
This PR fixes the issue mentioned in https://github.com/kelindar/bitmap/issues/14 - when bitmap is shrinking due to a `balance()`, the tail needs to be also reset to zero.