### PR TITLE
Different bitmap sizes support: speedup 'And', 'AndNot', fix 'AndNot', 'Or' and 'Xor'

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -128,8 +128,6 @@ func (dst *Bitmap) balance(src Bitmap) {
 		dst.grow(len(src) - 1)
 		return
 	}
-
-	dst.shrink(len(src))
 }
 
 // grow grows the size of the bitmap until we reach the desired block offset

--- a/bitmap_amd64.go
+++ b/bitmap_amd64.go
@@ -14,25 +14,35 @@ var (
 
 // And computes the intersection between two bitmaps and stores the result in the current bitmap
 func (dst *Bitmap) And(b Bitmap) {
-	if dst.balance(b); len(*dst) >= len(b) {
-		switch avx2 {
-		case true:
-			x64and(*dst, b)
-		default:
-			and(dst, b)
-		}
+	var min int
+	if len(b) >= len(*dst) {
+		min = len(*dst)
+	} else {
+		min = len(b)
+		dst.shrink(min)
+	}
+	switch avx2 {
+	case true:
+		x64and(*dst, b[:min])
+	default:
+		and(dst, b[:min])
 	}
 }
 
-// AndNot computes the difference between two bitmaps and stores the result in the current bitmap
+// AndNot computes the difference between two bitmaps and stores the result in the current bitmap.
+// Operation works as set subtract: dst - b
 func (dst *Bitmap) AndNot(b Bitmap) {
-	if dst.balance(b); len(*dst) >= len(b) {
-		switch avx2 {
-		case true:
-			x64andn(*dst, b)
-		default:
-			andn(dst, b)
-		}
+	var min int
+	if len(b) > len(*dst) {
+		min = len(*dst)
+	} else {
+		min = len(b)
+	}
+	switch avx2 {
+	case true:
+		x64andn(*dst, b[:min])
+	default:
+		andn(dst, b[:min])
 	}
 }
 

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -199,6 +199,45 @@ func TestAndNot(t *testing.T) {
 	}
 }
 
+func TestAndNot_TheSameBitmap(t *testing.T) {
+	var a Bitmap
+	for i := uint32(0); i < 100; i += 2 {
+		a.Set(i)
+	}
+
+	a.AndNot(a)
+
+	for i := uint32(0); i < 100; i++ {
+		assert.Equal(t, false, a.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	assert.Equal(t, 0, a.Count())
+}
+
+func TestAndNot_DifferentBitmapSizes(t *testing.T) {
+	var a, b, c, d Bitmap
+	for i := uint32(0); i < 100; i += 2 {
+		a.Set(i)
+		c.Set(i)
+	}
+
+	for i := uint32(0); i < 200; i += 2 {
+		b.Set(i)
+		d.Set(i)
+	}
+	a.AndNot(b)
+	d.AndNot(c)
+
+	for i := uint32(0); i < 100; i++ {
+		assert.Equal(t, false, a.Contains(i), "for "+strconv.Itoa(int(i)))
+		assert.Equal(t, false, d.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	for i := uint32(100); i < 200; i++ {
+		assert.Equal(t, b.Contains(i), d.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	assert.Equal(t, 0, a.Count())
+	assert.Equal(t, 50, d.Count())
+}
+
 func TestOr(t *testing.T) {
 	a, b := Bitmap{}, Bitmap{}
 	for i := uint32(0); i < 100; i += 2 {
@@ -212,6 +251,27 @@ func TestOr(t *testing.T) {
 	}
 }
 
+func TestOr_DifferentBitmapSizes(t *testing.T) {
+	var a, b, c, d Bitmap
+	for i := uint32(0); i < 100; i += 2 {
+		a.Set(i)
+		c.Set(i)
+	}
+
+	for i := uint32(0); i < 200; i += 2 {
+		b.Set(i)
+		d.Set(i)
+	}
+	a.Or(b)
+	d.Or(c)
+
+	for i := uint32(0); i < 200; i++ {
+		assert.Equal(t, d.Contains(i), a.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	assert.Equal(t, 100, a.Count())
+	assert.Equal(t, 100, d.Count())
+}
+
 func TestXor(t *testing.T) {
 	a, b := Bitmap{}, Bitmap{}
 	for i := uint32(0); i < 100; i += 2 {
@@ -223,6 +283,27 @@ func TestXor(t *testing.T) {
 	for i := uint32(0); i < 100; i += 2 {
 		assert.True(t, a.Contains(i))
 	}
+}
+
+func TestXOr_DifferentBitmapSizes(t *testing.T) {
+	var a, b, c, d Bitmap
+	for i := uint32(0); i < 100; i += 2 {
+		a.Set(i)
+		c.Set(i)
+	}
+
+	for i := uint32(0); i < 200; i += 2 {
+		b.Set(i)
+		d.Set(i)
+	}
+	a.Xor(b)
+	d.Xor(c)
+
+	for i := uint32(0); i < 200; i++ {
+		assert.Equal(t, d.Contains(i), a.Contains(i), "for "+strconv.Itoa(int(i)))
+	}
+	assert.Equal(t, 50, a.Count())
+	assert.Equal(t, 50, d.Count())
 }
 
 func TestMin(t *testing.T) {
@@ -360,24 +441,18 @@ func TestGrow(t *testing.T) {
 }
 
 func TestAnd_DifferentBitmapSizes(t *testing.T) {
-	a, b := Bitmap{}, Bitmap{}
+	var a, b, c, d Bitmap
 	for i := uint32(0); i < 100; i += 2 {
 		a.Set(i)
+		c.Set(i)
 	}
 
 	for i := uint32(0); i < 200; i += 2 {
 		b.Set(i)
+		d.Set(i)
 	}
 
 	a.And(b)
-
-	c, d := Bitmap{}, Bitmap{}
-	for i := uint32(0); i < 100; i += 2 {
-		c.Set(i)
-	}
-	for i := uint32(0); i < 200; i += 2 {
-		d.Set(i)
-	}
 	d.And(c)
 
 	for i := uint32(0); i < 200; i++ {


### PR DESCRIPTION
Hi,
There are 2 type of changes for _different bitmap sizes_

- Fix 'AndNot', 'Or' and 'Xor' operations
- Speedup 'And', 'AndNot'

### Fix 'AndNot', 'Or' and 'Xor'
- 'AndNot' works as set subtraction, this is what i believe expected from Readme
```
books.And(recent)
books.And(ebooks)
books.AndNot(bestsellers) 
```
![image](https://user-images.githubusercontent.com/9289172/133022375-f05f01ba-ffa0-493c-bc1a-1dc4b99bed9b.png)
- 'Or' and 'Xor' only growth if needed, never shrinks, so, actually i reverted `balance` function change introduced recently. We should take into consideration both one bits of `dst` and `b` bitmaps

### Speedup And
1. [0....1kk].And([0...1k]) = [0...1k]
ER=AR: dst bitmap shrinks to the smallest size
2. [0....1k].And([0...1kk]) = [0...1k]
ER: this PR fixes this case, it shrinks `dst` bitmap to the smallest possible size (`[0...1k]`)
AR: `dst` bitmap grows to `1kk` bitmap, while for 'And' operation the best possible result is `[0...1k]`

8 consecutive `And` bitmaps improvement

ER1: benefits for cases when position of `one bits` at the start
ER2: NO benefits for cases when position of `one bits` at the end

```
benchstat benchmark/500k-large-groups/kelindar/benchmark-results-old.txt benchmark/500k-large-groups/kelindar/benchmark-results-new.txt
name                               old time/op    new time/op    delta
FindPriceV2_11position               18.4µs ± 3%     1.3µs ± 9%  -93.13%  (p=0.000 n=8+10)
FindPriceV2_3824position             17.9µs ± 4%     2.8µs ± 5%  -84.64%  (p=0.000 n=10+10)
FindPriceV2_3824position_OptStats    19.9µs ± 5%     3.5µs ± 5%  -82.16%  (p=0.000 n=9+10)
FindPriceV2_9701position             22.3µs ± 7%    20.3µs ± 4%   -8.92%  (p=0.000 n=10+9)
FindPriceV2_MultiplePricesErr        15.1µs ± 2%     2.1µs ± 2%  -85.99%  (p=0.000 n=10+9)

name                               old alloc/op   new alloc/op   delta
FindPriceV2_11position                 177B ± 0%      176B ± 0%   -0.56%  (p=0.000 n=10+10)
FindPriceV2_3824position               177B ± 0%      176B ± 0%   -0.56%  (p=0.000 n=10+10)
FindPriceV2_3824position_OptStats      225B ± 0%      224B ± 0%   -0.44%  (p=0.000 n=10+10)
FindPriceV2_9701position               177B ± 0%      177B ± 0%     ~     (all equal)
FindPriceV2_MultiplePricesErr          128B ± 0%      128B ± 0%     ~     (all equal)

name                               old allocs/op  new allocs/op  delta
FindPriceV2_11position                 6.00 ± 0%      6.00 ± 0%     ~     (all equal)
FindPriceV2_3824position               6.00 ± 0%      6.00 ± 0%     ~     (all equal)
FindPriceV2_3824position_OptStats      11.0 ± 0%      11.0 ± 0%     ~     (all equal)
FindPriceV2_9701position               6.00 ± 0%      6.00 ± 0%     ~     (all equal)
FindPriceV2_MultiplePricesErr          4.00 ± 0%      4.00 ± 0%     ~     (all equal)

```