### PR TITLE
Add checks for From/ToBytes

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -5,6 +5,7 @@ package bitmap
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"reflect"
 	"unsafe"
@@ -12,6 +13,13 @@ import (
 
 // FromBytes reads a bitmap from a byte buffer without copying the buffer.
 func FromBytes(buffer []byte) (out Bitmap) {
+	switch {
+	case len(buffer) == 0:
+		return nil
+	case len(buffer)%8 != 0:
+		panic(fmt.Sprintf("bitmap: buffer length expected to be multiple of 8, was %d", len(buffer)))
+	}
+
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&out))
 	hdr.Len = len(buffer) >> 3
 	hdr.Cap = hdr.Len
@@ -22,6 +30,10 @@ func FromBytes(buffer []byte) (out Bitmap) {
 // ToBytes converts the bitmap to binary representation without copying the underlying
 // data. The output buffer should not be modified, since it would also change the bitmap.
 func (dst *Bitmap) ToBytes() (out []byte) {
+	if len(*dst) == 0 {
+		return nil
+	}
+
 	hdr := (*reflect.SliceHeader)(unsafe.Pointer(&out))
 	hdr.Len = len(*dst) * 8
 	hdr.Cap = hdr.Len

--- a/codec_test.go
+++ b/codec_test.go
@@ -51,3 +51,23 @@ func TestFromBytes(t *testing.T) {
 	out := FromBytes(m.ToBytes())
 	assert.Equal(t, m, out)
 }
+
+func TestFromBytesNil(t *testing.T) {
+	out := FromBytes(nil)
+	assert.Nil(t, out)
+}
+
+func TestFromBytesInvalid(t *testing.T) {
+	m := make([]byte, 10)
+	for i := 1; i < 8; i++ {
+		assert.Panics(t, func() {
+			FromBytes(m[:i])
+		})
+	}
+}
+
+func TestToBytesNil(t *testing.T) {
+	var m Bitmap
+	out := m.ToBytes()
+	assert.Nil(t, out)
+}


### PR DESCRIPTION
Add checks to `FromBytes()` and `ToBytes()` methods when the input is nil. `FromBytes()` will now panic if the input buffer provided is not a multiple of 8. Fixes https://github.com/kelindar/bitmap/issues/20