### PR TITLE
Fix Compiler Directives

### DIFF
--- a/simd_apple.go
+++ b/simd_apple.go
@@ -5,29 +5,38 @@ package bitmap
 
 import "unsafe"
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _count(a unsafe.Pointer, size uint64, result unsafe.Pointer)

--- a/simd_avx.go
+++ b/simd_avx.go
@@ -5,29 +5,38 @@ package bitmap
 
 import "unsafe"
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _count(a unsafe.Pointer, size uint64, result unsafe.Pointer)

--- a/simd_avx512.go
+++ b/simd_avx512.go
@@ -5,26 +5,34 @@ package bitmap
 
 import "unsafe"
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and_avx512(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn_avx512(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or_avx512(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor_avx512(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and_many_avx512(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn_many_avx512(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or_many_avx512(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor_many_avx512(a unsafe.Pointer, b unsafe.Pointer, dims uint64)

--- a/simd_neon.go
+++ b/simd_neon.go
@@ -5,29 +5,38 @@ package bitmap
 
 import "unsafe"
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor(a unsafe.Pointer, b unsafe.Pointer, n uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _and_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _andn_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _or_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _xor_many(a unsafe.Pointer, b unsafe.Pointer, dims uint64)
 
-//go:noescape,nosplit
+//go:nosplit
+//go:noescape
 func _count(a unsafe.Pointer, size uint64, result unsafe.Pointer)


### PR DESCRIPTION
`//go:noescape,nosplit` is not correct directives.

The correct one is 
```go
//go:nosplit
//go:noescape
func _count(...)
```

The origin code leaks the paramter to heap:
![image](https://github.com/user-attachments/assets/2394b076-a2c1-4729-8fa9-3f7eb6a4b39d)

This PR fixes it and can gain 10% speedup for `QueryKey`.

Speedup:
![image](https://github.com/user-attachments/assets/749502df-b96a-4c0e-962c-fcdc83620d86)


![image](https://github.com/user-attachments/assets/119123b9-596a-408f-8663-067660692b68)
