### PR TITLE
Fix fromHex endianness on big-endian architectures (s390x)

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -170,22 +170,29 @@ func (dst *Bitmap) UnmarshalJSON(data []byte) (err error) {
 
 // fromHex reads a hexadecimal string and converts it to bitmap, character at index 0 is the most significant
 func fromHex(hexString string) (Bitmap, error) {
-	bytes, err := hex.DecodeString(hexString)
+	b, err := hex.DecodeString(hexString)
 
 	switch {
 	case err != nil:
 		return nil, err
-	case len(bytes) == 0:
+	case len(b) == 0:
 		return nil, nil
 	}
 
-	// reverse bytes to maintain bytes significance order (least significant = hexString tail = list head)
-	for l, r := 0, len(bytes)-1; l < r; l, r = l+1, r-1 {
-		bytes[l], bytes[r] = bytes[r], bytes[l]
+	// reverse bytes into little-endian order (least significant = hexString tail = list head)
+	for l, r := 0, len(b)-1; l < r; l, r = l+1, r-1 {
+		b[l], b[r] = b[r], b[l]
 	}
 
-	for len(bytes)%8 != 0 {
-		bytes = append(bytes, 0)
+	for len(b)%8 != 0 {
+		b = append(b, 0)
 	}
-	return FromBytes(bytes), nil
+
+	// Use explicit little-endian decoding instead of unsafe pointer cast
+	// to produce correct results on big-endian architectures (e.g. s390x).
+	out := make(Bitmap, len(b)/8)
+	for i := range out {
+		out[i] = binary.LittleEndian.Uint64(b[i*8 : (i+1)*8])
+	}
+	return out, nil
 }


### PR DESCRIPTION
Fixes #47

Hello, first from all, thanks for this project. I was packaging this for debian, and found 
the issue in CI that was reported on #47 

This is a little patch.

Summary:

The `fromHex` function reverses decoded hex bytes into little-endian
order, then calls `FromBytes()` which uses an `unsafe.Pointer` cast to
reinterpret `[]byte` as `[]uint64`. This cast interprets bytes in native
byte order, so on big-endian systems (e.g. s390x) the uint64 values come
out byte-swapped.

For example, hex string `"FFA001"` produces:
- Little-endian (amd64, arm64): `0xFFA001` (correct)
- Big-endian (s390x): `0x01A0FF0000000000` (wrong)

The fix replaces the `FromBytes()` call with explicit
`binary.LittleEndian.Uint64()` decoding, which produces correct results
regardless of the host byte order. All existing tests continue to pass
on little-endian, and the two failing tests (TestJSON, TestFromHex)
are fixed on big-endian.

For the origin where we found this bug in Debian. CI: where autopkgtest
runs on s390x among other architectures:
https://ci.debian.net/packages/g/golang-github-kelindar-bitmap/testing/s390x/71172418/