### PR TITLE
Clear a reused destination past the source in Clone

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -104,7 +104,8 @@ func (dst Bitmap) Clone(into *Bitmap) Bitmap {
 	into.grow(max - 1)
 
 	copy(*into, dst)
-	return (*into)[:len(dst)]
+	into.shrink(len(dst)) // reused destinations may hold bits past the source's length
+	return *into
 }
 
 // Clear clears the bitmap and resizes it to zero.

--- a/codec_test.go
+++ b/codec_test.go
@@ -221,3 +221,19 @@ func TestLevelOfWithEnabledFeatures(t *testing.T) {
 		})
 	}
 }
+
+func TestCloneIntoLargerDestination(t *testing.T) {
+	var src Bitmap
+	src.Set(1)
+
+	into := Bitmap{}
+	into.Set(300)
+	into.Set(500)
+
+	clone := src.Clone(&into)
+	assert.Equal(t, src, into)
+	assert.Equal(t, src, clone)
+
+	clone.Set(400)
+	assert.False(t, clone.Contains(300))
+}


### PR DESCRIPTION
`Clone` does not clear a destination that is longer than the source.

`codec.go:104` grows `into` to the larger of the two, copies, then returns a truncated view:

```go
max := maxlen(*into, dst, nil)
into.grow(max - 1)

copy(*into, dst)
return (*into)[:len(dst)]
```

`copy` writes only `len(dst)` words. Anything past that in `into` survives, so the caller's
bitmap ends up holding `src` **plus** whatever it had before - which contradicts the doc
comment, "the bitmap will be cloned inside".

Reusing a destination is the documented reason the parameter exists (README: "reusability"), so
this is the case it is meant for. Two-line reproduction:

```go
var src bitmap.Bitmap
src.Set(1)

into := bitmap.Bitmap{}
into.Set(300)
into.Set(500)

clone := src.Clone(&into)
```

```
before: len(src)=1 len(into)=8
after : len(into)=8  into.Contains(300)=true  into.Contains(500)=true
clone : len=1        contains300=false        contains500=false
```

The returned slice looks right, but it shares the array with the stale words, and `grow`
(`bitmap.go:150`) reuses capacity without zeroing:

```go
if cap(*dst) > blkAt {
    *dst = (*dst)[:blkAt+1]
    return
}
```

So the next write brings them back:

```
after clone.Set(400): len=7  contains300=true  contains500=false
```

A bit the source never had is now set in the clone.

### The change

Two lines, using the package's own `shrink` (`bitmap.go:167`), which zeroes the tail and then
trims without reallocating - so a reused destination keeps its capacity:

```go
 	copy(*into, dst)
-	return (*into)[:len(dst)]
+	into.shrink(len(dst)) // reused destinations may hold bits past the source's length
+	return *into
```

### Test

`TestCloneIntoLargerDestination` in `codec_test.go`, covering both halves: `into` equals the
source after the call, and a subsequent `Set` does not resurrect a stale bit. With the change
reverted:

```
--- FAIL: TestCloneIntoLargerDestination
    expected: bitmap.Bitmap{0x2}
    actual  : bitmap.Bitmap{0x2, 0x0, 0x0, 0x0, 0x100000000000, 0x0, 0x0, 0x10000000000000}
```

Both CI commands pass with the change:

```
go test -tags noasm -race ./...   ok  github.com/kelindar/bitmap  1.028s
go test -race ./...               ok  github.com/kelindar/bitmap  1.029s
```

`gofmt -l` and `go vet` are clean on `codec.go` and `codec_test.go`; both report the same
pre-existing findings in the generated and assembly files with or without this change.

---

Disclosure: found and prepared with AI assistance (Claude). Every figure above is from a run on
this branch.
