### PR TITLE
Fix Or/Xor dropping bits when combining bitmaps of different lengths

### DIFF
--- a/bitmap_amd64.go
+++ b/bitmap_amd64.go
@@ -83,16 +83,30 @@ func (dst *Bitmap) Or(other Bitmap, extra ...Bitmap) {
 		case 0:
 			_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_or_many(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			// _or_many uses one word count for every input, so it cannot union
+			// bitmaps of different lengths. Union each source over its own.
+			if len(other) > 0 {
+				_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	case isAVX512:
 		switch len(extra) {
 		case 0:
 			_or_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_or_many_avx512(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			if len(other) > 0 {
+				_or_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_or_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	default:
 		or(*dst, other, extra)
@@ -113,16 +127,30 @@ func (dst *Bitmap) Xor(other Bitmap, extra ...Bitmap) {
 		case 0:
 			_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_xor_many(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			// _xor_many uses one word count for every input, so it cannot combine
+			// bitmaps of different lengths. Fold in each source over its own.
+			if len(other) > 0 {
+				_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	case isAVX512:
 		switch len(extra) {
 		case 0:
 			_xor_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_xor_many_avx512(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			if len(other) > 0 {
+				_xor_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_xor_avx512(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	default:
 		xor(*dst, other, extra)

--- a/bitmap_arm64.go
+++ b/bitmap_arm64.go
@@ -67,8 +67,16 @@ func (dst *Bitmap) Or(other Bitmap, extra ...Bitmap) {
 		case 0:
 			_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_or_many(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			// _or_many uses one word count for every input, so it cannot union
+			// bitmaps of different lengths. Union each source over its own.
+			if len(other) > 0 {
+				_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_or(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	default:
 		or(*dst, other, extra)
@@ -89,8 +97,16 @@ func (dst *Bitmap) Xor(other Bitmap, extra ...Bitmap) {
 		case 0:
 			_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
 		default:
-			vx, max := pointersOf(other, extra)
-			_xor_many(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
+			// _xor_many uses one word count for every input, so it cannot combine
+			// bitmaps of different lengths. Fold in each source over its own.
+			if len(other) > 0 {
+				_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&other[0]), uint64(len(other)))
+			}
+			for i := range extra {
+				if len(extra[i]) > 0 {
+					_xor(unsafe.Pointer(&(*dst)[0]), unsafe.Pointer(&extra[i][0]), uint64(len(extra[i])))
+				}
+			}
 		}
 	default:
 		xor(*dst, other, extra)

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -629,3 +629,49 @@ func testTruthTables(t *testing.T) {
 		assert.Equal(t, 0b0110, int(a[0]))
 	}
 }
+
+func TestOr_ExtraDifferentBitmapSizes(t *testing.T) {
+	// Ragged inputs: every set bit must survive regardless of which is longest.
+	var dst Bitmap
+	dst.Set(1)  // word 0
+	dst.Set(70) // word 1
+
+	var other Bitmap
+	other.Set(3)   // word 0
+	other.Set(200) // word 3, beyond every extra bitmap
+
+	var short Bitmap
+	short.Set(5) // word 0 only
+
+	var mid Bitmap
+	mid.Set(130) // word 2
+
+	dst.Or(other, short, mid)
+
+	want := []uint32{1, 70, 3, 200, 5, 130}
+	for _, v := range want {
+		assert.True(t, dst.Contains(v), "missing bit "+strconv.Itoa(int(v)))
+	}
+	assert.Equal(t, len(want), dst.Count())
+}
+
+func TestXor_ExtraDifferentBitmapSizes(t *testing.T) {
+	var dst Bitmap
+	dst.Set(1)
+	dst.Set(200) // shared with other, must cancel out
+
+	var other Bitmap
+	other.Set(200) // cancels dst's bit 200
+	other.Set(201) // survives, beyond every extra bitmap
+
+	var short Bitmap
+	short.Set(5)
+
+	dst.Xor(other, short)
+
+	assert.True(t, dst.Contains(1))
+	assert.False(t, dst.Contains(200), "bit 200 should cancel")
+	assert.True(t, dst.Contains(201), "bit 201 from longer source must survive")
+	assert.True(t, dst.Contains(5))
+	assert.Equal(t, 3, dst.Count())
+}


### PR DESCRIPTION

## Problem

`Bitmap.Or` and `Bitmap.Xor` silently drop set bits when called with one or
more `extra` bitmaps whose lengths differ from `other`.

The library explicitly supports operands of different sizes: the two-argument
forms are covered by `TestOr_DifferentBitmapSizes` and
`TestXOr_DifferentBitmapSizes`, and the scalar reference implementations in
`simd_generic.go` fold each source in over its own length. The variadic
(`extra ...Bitmap`) path on accelerated hardware does not honor that contract.

Example (AVX2/NEON hardware):

```go
var dst, other, extra bitmap.Bitmap
dst.Set(1)
other.Set(200) // word 3
extra.Set(2)   // word 0
dst.Or(other, extra)
// dst.Contains(200) == false  -- bit 200 is lost
```

## Root cause

`bitmap_amd64.go` / `bitmap_arm64.go`, the `default` (len(extra) > 0) branch of
`Or` and `Xor`:

```go
vx, max := pointersOf(other, extra)
_or_many(unsafe.Pointer(&(*dst)[0]), vx, dimensionsOf(max, len(extra)+1))
```

Two problems:

1. `pointersOf` (`bitmap.go:239`) computes its returned length as the maximum
   over the `extra` slice only; it never considers `len(other)`. By shadowing
   the outer `max` (the true `maxlen` over dst/other/extra) with this value,
   `Or`/`Xor` pass a word count that excludes `other`. When `other` is the
   longest operand, its tail words are never combined into `dst`.

2. More fundamentally, `_or_many`/`_xor_many` apply a single word count to every
   input. That is correct only when all inputs share that width. For a union or
   symmetric difference the result must span the longest input while each source
   is read only up to its own length, so no single count is correct for
   different-sized operands: a source longer than the count loses its tail, and
   a source shorter than the count is read past its end.

`And`/`AndNot` are unaffected: they discard `pointersOf`'s length (`vx, _ :=`)
and use the outer `max`, which for intersection/difference is `minlen`, so every
operand is at least that long and the uniform count is safe.

## Fix

In the variadic branch of `Or` and `Xor`, fold each source in individually with
the single-operand SIMD primitive (`_or` / `_xor`, and the AVX-512 variants),
each over its own length. This matches the scalar reference in `simd_generic.go`
exactly, keeps SIMD acceleration per operand, and never reads past a source.
Applied to both `bitmap_amd64.go` (accelerated and AVX-512 branches) and
`bitmap_arm64.go`.

## Test

Added `TestOr_ExtraDifferentBitmapSizes` and `TestXor_ExtraDifferentBitmapSizes`
to `bitmap_test.go`, which union/xor operands spanning different numbers of
words (including an `other` that reaches beyond every `extra` bitmap) and assert
every expected bit and the final `Count`.
